### PR TITLE
ffmpeg 6.0 support and new baseline dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Nightfall is a library used internally by [Dim](https://github.com/vgarleanu/dim
 3. Subtitle streaming
 
 # Dependencies
-`ffmpeg` > 4.1
+`ffmpeg` > 6.0

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Nightfall is a library used internally by [Dim](https://github.com/vgarleanu/dim
 3. Subtitle streaming
 
 # Dependencies
-`ffmpeg` > 6.0
+`ffmpeg` >= 6.0

--- a/src/profiles/audio.rs
+++ b/src/profiles/audio.rs
@@ -84,12 +84,12 @@ impl TranscodingProfile for AacTranscodeProfile {
         // timestamp.
         if ctx.output_ctx.start_num > 0 {
             args.append(&mut vec![
-                "-hls_ts_options".into(), 
+                "-hls_segment_options".into(),
                 "movflags=frag_custom+dash+delay_moov+frag_discont".into(),
             ]);
         } else {
             args.append(&mut vec![
-                "-hls_ts_options".into(), 
+                "-hls_segment_options".into(),
                 "movflags=frag_custom+dash+delay_moov".into(),
             ]);
         }

--- a/src/profiles/video.rs
+++ b/src/profiles/video.rs
@@ -332,12 +332,12 @@ pub(super) fn get_discont_flags(ctx: &ProfileContext) -> Vec<String> {
     // timestamp.
     if ctx.output_ctx.start_num > 0 {
         vec![
-            "-hls_ts_options".into(), 
+            "-hls_segment_options".into(),
             "movflags=frag_custom+dash+delay_moov+frag_discont".into(),
         ]
     } else {
         vec![
-            "-hls_ts_options".into(), 
+            "-hls_segment_options".into(),
             "movflags=frag_custom+dash+delay_moov".into(),
         ]
     }


### PR DESCRIPTION
ffmpeg 6.0 renames `hls_ts_options ` to `hls_segment_options`

This change is not backwards compatible with older versions of ffmpeg so I understand if this isn't something we're ready to adopt yet.

Assuming this is accepted, https://github.com/Dusk-Labs/dim/commit/f67994d3d2bdfbf11ef7b5a1493d9d196b5832b4 changes to`.github/workflows/Dockerfile.ci` will need to be reverted.

This will also properly close:
- https://github.com/Dusk-Labs/dim/issues/554
- https://github.com/Dusk-Labs/dim/issues/547