### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.5.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.27.1"
+nix = "0.26"
 psutil = { version = "3.2.0", default-features = false, features = ["process"] }
 rusty_vainfo = { version = "0.1.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.5.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.26"
+nix = "0.27.1"
 psutil = { version = "3.2.0", default-features = false, features = ["process"] }
 rusty_vainfo = { version = "0.1.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.5.0", features = [
 ] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.26"
+nix = { version = "0.27.1", features = ["signal"] }
 psutil = { version = "3.2.0", default-features = false, features = ["process"] }
 rusty_vainfo = { version = "0.1.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ssa_transmux = []
 default = ["cuda", "vaapi"]
 
 [dependencies]
-uuid = { version = "0.8.1", features = ["v4"] }
+uuid = { version = "1.6.1", features = ["v4"] }
 lazy_static = "1.4.0"
 serde_json = "1.0.57"
 serde = { version = "1.0.115", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ psutil = { version = "3.2.0", default-features = false, features = ["process"] }
 rusty_vainfo = { version = "0.1.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ntapi = "^0.3.6"
+ntapi = "0.4.1"
 winapi = { version = "^0.3.9", features = [
     "winerror",
     "synchapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,9 @@ rusty_vainfo = { version = "0.1.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ntapi = "0.4.1"
-winapi = { version = "^0.3.9", features = [
+winapi = { version = "0.3.9", features = [
     "winerror",
     "synchapi",
     "minwinbase",
+    "processthreadsapi",
 ] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,7 +31,6 @@ cfg_if::cfg_if! {
         use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
         use winapi::um::processthreadsapi::OpenProcess;
         use winapi::um::processthreadsapi::GetExitCodeProcess;
-        use winapi::shared::winerror::WAIT_TIMEOUT;
         use winapi::um::minwinbase::STILL_ACTIVE;
         use winapi::shared::ntdef::NULL;
 


### PR DESCRIPTION
Bumped the versions of `ntapi`, `nix` and `uuid`, and added the feature flags required for compiling with resolver version 2.